### PR TITLE
fix typo

### DIFF
--- a/pkg/apis/project/validation/validation.go
+++ b/pkg/apis/project/validation/validation.go
@@ -81,7 +81,7 @@ func ValidateProjectUpdate(newProject *project.Project, oldProject *project.Proj
 
 	for name, value := range newProject.Labels {
 		if value != oldProject.Labels[name] {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "labels").Key(name), value, "field is immutable, , try updating the namespace"))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "labels").Key(name), value, "field is immutable, try updating the namespace"))
 		}
 	}
 	for name, value := range oldProject.Labels {


### PR DESCRIPTION
If you try to update a label using the Project API there's a typo on the error message:

```
* metadata.labels[test]: Invalid value: "demo": field is immutable, , try updating the namespace
```

